### PR TITLE
Fix write order of TYPE headings on CounterVectorCombined in Prometheus export

### DIFF
--- a/examples/vpp_prometheus_export.rs
+++ b/examples/vpp_prometheus_export.rs
@@ -59,16 +59,17 @@ fn write_stat_data(data: &VppStatData<'_>) -> String {
                 }
             }
             CounterVectorCombined(cvc) => {
-                writeln!(out, "# TYPE {}_packets counter", name);
-                writeln!(out, "# TYPE {}_bytes counter", name);
                 for k in 0..cvc.len() {
                     let cvc_k = &cvc[k];
                     for j in 0..cvc_k.len() {
+                        writeln!(out, "# TYPE {}_packets counter", name);
                         writeln!(
                             out,
                             "{}_packets{{thread=\"{}\",interface=\"{}\"}} {}",
                             name, k, j, cvc_k[j].packets
                         );
+
+                        writeln!(out, "# TYPE {}_bytes counter", name);
                         writeln!(
                             out,
                             "{}_bytes{{thread=\"{}\",interface=\"{}\"}} {}",


### PR DESCRIPTION
## Problem

For `CounterVectorCombined` metrics, the original metric from VPP is transformed into into two new separate metrics, a packets counter and a byte counter.  When these two new metrics were written into HTTP response output, the `#  TYPE` headings were being written in the wrong order, which prevented our Prometheus agent from properly parsing these metrics.

**Example:**
The original metric from our VPP instance was `/interfaces/GigabitEthernet0_4_0/rx`.  It was transformed into the following two  metrics:

```
# TYPE _interfaces_GigabitEthernet0_4_0_rx_packets counter
# TYPE _interfaces_GigabitEthernet0_4_0_rx_bytes counter
_interfaces_GigabitEthernet0_4_0_rx_packets{thread="0",interface="0"} 42179
_interfaces_GigabitEthernet0_4_0_rx_bytes{thread="0",interface="0"} 4322287
```

We configured our Prometheus agent to scrape these two new metrics, but they were not reported by the agent.
```
instances:
  - openmetrics_endpoint: http://localhost:8000/metrics
    namespace: foo
    metrics:
      - _interfaces_GigabitEthernet0_4_0_rx_packets: vpp_gigabitethernet040_rx_packets
      - _interfaces_GigabitEthernet0_4_0_rx_bytes: vpp_gigabitethernet040_rx_bytes
```

## Proposed Fix

Per our understanding, each separate metric in a Prometheus-style format needs to have its own `# TYPE` heading preceding it.   For the `CounterVectorCombined` objects only, this PR writes the heading in the same loop as when the actual metric line is written so that the heading always precedes the metrics it describes.